### PR TITLE
Use official name of Durable PushTopic Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Salesforce PushTopic Streaming v2 Demo
-This repository contains all the code you need to set up a PushTopic Streaming v2 client inside of a Visualforce page in your Salesforce org.  PushTopic Streaming v2 adds the capability to replay any of the messages sent to the PushTopic for the last 24 hours.
+# Salesforce Durable PushTopic Streaming Demo
+This repository contains all the code you need to set up a Durable PushTopic Streaming client inside of a Visualforce page in your Salesforce org.  Durable PushTopic Streaming adds the capability to replay any of the messages sent to the PushTopic for the last 24 hours.
 
-This is handled through the use of an Replay ID.  Every event sent through the PushTopic Streaming system will have an associated ID.  With v2, you will have the ability to provide a Replay ID (ostensibly the last ID that your client has received) and the system will send every event that has happened in the last 24 hours after that specific ID.
+This is handled through the use of an Replay ID.  Every event sent through the PushTopic Streaming system will have an associated ID.  With Durable PushTopic Streaming, you will have the ability to provide a Replay ID (ostensibly the last ID that your client has received) and the system will send every event that has happened in the last 24 hours after that specific ID.
 
 If you do not provide an ID, or the ID you provide is -1, your client will be subscribed to the tip of the queue (you will receive all new messages).  If you provide an ID of -2, we resend ALL events that happened in the last 24 hours.
 
 ## Prerequisites
-PushTopic Streaming v2 is currently a Beta feature in Salesforce, and in order to successfully subscribe to the v2 topic, you will need to have your org enabled for the new feature.  To do so, please contact jhurst@salesforce.com. 
+Durable PushTopic Streaming is currently a Beta feature in Salesforce, and in order to successfully subscribe to the durable topic, you will need to have your org enabled for the new feature.  To do so, please contact jhurst@salesforce.com. 
 
 ## Demo Instructions
 1. Download this repo as zip file
     * This contains all of the needed code to run the client inside of Salesforce
 2. Deploy the code to an enabled Spring '16 org using the MdAPI through Workbench, Force.com IDE, or Ant Migration Tool
 3. Assign the included StreamingV2PushTopicDemo permission set to your user
-4. Create the `/topic/TestAccountStreaming` PushTopic by navigating to `/apex/StreamingPushTopicV2Demo` - this Visualforce page will create the topic then auto-subscribe to `/topic/TestAccountStreaming` using PushTopic Streaming v2.
+4. Create the `/topic/TestAccountStreaming` PushTopic by navigating to `/apex/StreamingPushTopicV2Demo` - this Visualforce page will create the topic then auto-subscribe to `/topic/TestAccountStreaming` using Durable PushTopic Streaming.
 5. Create notifications for the new topic
     * Use the on-screen utility to create, update and then delete an Account record
     * Or, use the UI or API to create, update, delete or undelete an Account record  

--- a/components/StreamingPushTopicMessageDisplay.component
+++ b/components/StreamingPushTopicMessageDisplay.component
@@ -23,7 +23,7 @@
                  cometd.unregisterExtension(REPLAY_FROM, replayExtension);                 
              }
 
-            // register streaming v2 replayFrom extension
+            // register Durable PushTopic Streaming replayFrom extension
              var replayExtension = new cometdReplayExtension();
              replayExtension.setChannel(channel);
              replayExtension.setReplay('{!replayFrom}');


### PR DESCRIPTION
Spring '16 Release Notes use 'Durable PushTopic Streaming' as the name for this feature - see http://docs.releasenotes.salesforce.com/en-us/spring16/release-notes/rn_api_streaming_classic_replay.htm